### PR TITLE
Fix version numbers in eclipse-repository/category.xml

### DIFF
--- a/eclipse-repository/category.xml
+++ b/eclipse-repository/category.xml
@@ -17,23 +17,23 @@
     </description>
 
     <feature
-            url="features/org.bitstrings.eclipse.m2e.connectors.dependencypath_2.0.0.qualifier.jar"
+            url="features/org.bitstrings.eclipse.m2e.connectors.dependencypath_3.0.0.qualifier.jar"
             id="org.bitstrings.eclipse.m2e.connectors.dependencypath.features"
-            version="2.0.0.qualifier">
+            version="3.0.0.qualifier">
         <category name="org.bitstrings.eclipse.m2e.connectors"/>
     </feature>
 
     <feature
-            url="features/org.bitstrings.eclipse.m2e.connectors.jaxb2_2.0.0.qualifier.jar"
+            url="features/org.bitstrings.eclipse.m2e.connectors.jaxb2_3.0.0.qualifier.jar"
             id="org.bitstrings.eclipse.m2e.connectors.jaxb2.features"
-            version="2.0.0.qualifier">
+            version="3.0.0.qualifier">
         <category name="org.bitstrings.eclipse.m2e.connectors"/>
     </feature>
 
     <feature
-            url="features/org.bitstrings.eclipse.m2e.connectors.xmlbeans_2.0.0.qualifier.jar"
+            url="features/org.bitstrings.eclipse.m2e.connectors.xmlbeans_3.0.0.qualifier.jar"
             id="org.bitstrings.eclipse.m2e.connectors.xmlbeans.features"
-            version="2.0.0.qualifier">
+            version="3.0.0.qualifier">
         <category name="org.bitstrings.eclipse.m2e.connectors"/>
     </feature>
 


### PR DESCRIPTION
Updated the version numbers in eclipse-repository/category.xml to allow the p2 repo to be built successfully.

This version of jaxb2-m2e-connector appears to resolve a conflict I was seeing with the newest version of m2e.
